### PR TITLE
Fix Makefile to make sure `gravcalc_parallel` is compiled with the correct flags

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC=
 CFLAGS=-Ofast -fno-automatic -fd-lines-as-code -ffixed-line-length-none -std=legacy
-CFLAGS_INTF=
+CFLAGS_INTF=-std=legacy
 
 UNAME := $(shell uname)
 
@@ -16,7 +16,7 @@ ifeq ($(UNAME), Darwin)
   CFLAGS_INTF += -lpgplot -L/opt/X11/lib -I/opt/X11/include -lX11 -L/usr/local/opt/pgplot/lib -I/usr/local/opt/pgplot/include  -fd-lines-as-comments -lpng 
 endif
 
-all: litmod litmod_intf litmod2
+all: litmod gravcalc_parallel litmod_intf litmod2
 
 interface: litmod_intf
 
@@ -25,7 +25,8 @@ litmod:
 	cp src/conductionNd_serial.py conductionNd_serial.py
 	cp src/temperature_solver.py temperature_solver.py
 
-	$(CC) -o gravcalc_parallel src/modules.for src/gravcalc_parallel.for src/SUB_Geo_Grad3D.for src/SUB_GeoGrav_Grad3D.for src/SUB_Grav_Grad3D.for src/SUB_SumTan.for src/SUB_U_SECOND_DER.for
+gravcalc_parallel:
+	$(CC) -o gravcalc_parallel src/modules.for src/gravcalc_parallel.for src/SUB_Geo_Grad3D.for src/SUB_GeoGrav_Grad3D.for src/SUB_Grav_Grad3D.for src/SUB_SumTan.for src/SUB_U_SECOND_DER.for $(CFLAGS)
 	cp src/gravity_calculator.py gravity_calculator.py
 	
 	cp src/periods.py periods.py


### PR DESCRIPTION
### Problem solved here

On some systems (e.g., a `conda`-installed `gfortran`), we run into problems which are ultimately related to implicit variable declarations resulting in some variables being implicitly declared as `real(4)` which then conflicts with the otherwise used types `real(8)`. While the compiler flags set for most make targets handle this, they were missing for the `gravcalc_parallel` binary.

### Solution

This PR adds the correct `$(CFLAGS)` to the compilation of `gravcalc_parallel` and also makes sure there's a separate make target for `gravcalc_parallel`.